### PR TITLE
Fix null handling in bcrypt comparison

### DIFF
--- a/src/main/java/com/topnotch/bcryptGenerator/model/BCryptObject.java
+++ b/src/main/java/com/topnotch/bcryptGenerator/model/BCryptObject.java
@@ -33,6 +33,14 @@ public class BCryptObject {
     }
 
     public boolean isEqual(PasswordEncoder passwordEncoder){
+        if (data == null || data.isEmpty()) {
+            return false;
+        }
+
+        if (encryptedString == null || encryptedString.isEmpty()) {
+            return false;
+        }
+
         return passwordEncoder.matches(data, encryptedString);
     }
 


### PR DESCRIPTION
## Summary
- handle null and empty strings when comparing bcrypt hashes

## Testing
- `sh mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_683f46ac394c8330bf0fa4e8f2e37a71