### PR TITLE
Add PasswordEncoder factory

### DIFF
--- a/src/main/java/com/topnotch/bcryptGenerator/config/BCryptGeneratorAppConfig.java
+++ b/src/main/java/com/topnotch/bcryptGenerator/config/BCryptGeneratorAppConfig.java
@@ -4,11 +4,16 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import com.topnotch.bcryptGenerator.factory.PasswordEncoderFactory;
+import com.topnotch.bcryptGenerator.model.HashingAlgorithm;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Configuration
 public class BCryptGeneratorAppConfig extends WebSecurityConfigurerAdapter {
+
+    @Value("${hashing.algorithm:BCRYPT}")
+    private String algorithmProperty;
 
     @Override
     protected void configure(HttpSecurity http) throws Exception {
@@ -17,7 +22,8 @@ public class BCryptGeneratorAppConfig extends WebSecurityConfigurerAdapter {
     }
 
     @Bean
-    public PasswordEncoder getPasswordEncoder(){
-        return new BCryptPasswordEncoder();
+    public PasswordEncoder getPasswordEncoder() {
+        HashingAlgorithm algorithm = HashingAlgorithm.valueOf(algorithmProperty.toUpperCase());
+        return PasswordEncoderFactory.create(algorithm);
     }
 }

--- a/src/main/java/com/topnotch/bcryptGenerator/factory/PasswordEncoderFactory.java
+++ b/src/main/java/com/topnotch/bcryptGenerator/factory/PasswordEncoderFactory.java
@@ -1,0 +1,44 @@
+package com.topnotch.bcryptGenerator.factory;
+
+import com.topnotch.bcryptGenerator.model.HashingAlgorithm;
+import org.springframework.security.crypto.argon2.Argon2PasswordEncoder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.crypto.password.Pbkdf2PasswordEncoder;
+import org.springframework.security.crypto.scrypt.SCryptPasswordEncoder;
+
+/**
+ * Factory for {@link PasswordEncoder} implementations.
+ */
+public final class PasswordEncoderFactory {
+
+    private PasswordEncoderFactory() {
+        // Utility class
+    }
+
+    /**
+     * Create a {@link PasswordEncoder} for the given algorithm.
+     *
+     * @param algorithm the desired algorithm
+     * @return an appropriate {@link PasswordEncoder}
+     */
+    public static PasswordEncoder create(HashingAlgorithm algorithm) {
+        if (algorithm == null) {
+            throw new IllegalArgumentException("algorithm must not be null");
+        }
+        switch (algorithm) {
+            case SCRYPT:
+                return new SCryptPasswordEncoder();
+            case PBKDF2:
+                return Pbkdf2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+            case ARGON2:
+                return Argon2PasswordEncoder.defaultsForSpringSecurity_v5_8();
+            case NOOP:
+                return NoOpPasswordEncoder.getInstance();
+            case BCRYPT:
+            default:
+                return new BCryptPasswordEncoder();
+        }
+    }
+}

--- a/src/main/java/com/topnotch/bcryptGenerator/model/HashingAlgorithm.java
+++ b/src/main/java/com/topnotch/bcryptGenerator/model/HashingAlgorithm.java
@@ -1,0 +1,12 @@
+package com.topnotch.bcryptGenerator.model;
+
+/**
+ * Supported hashing algorithms.
+ */
+public enum HashingAlgorithm {
+    BCRYPT,
+    SCRYPT,
+    PBKDF2,
+    ARGON2,
+    NOOP
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 welcome.message=Welcome to the BCrypt Encoder
+hashing.algorithm=BCRYPT

--- a/src/test/java/com/topnotch/bcryptGenerator/factory/PasswordEncoderFactoryTests.java
+++ b/src/test/java/com/topnotch/bcryptGenerator/factory/PasswordEncoderFactoryTests.java
@@ -1,0 +1,28 @@
+package com.topnotch.bcryptGenerator.factory;
+
+import com.topnotch.bcryptGenerator.model.HashingAlgorithm;
+import org.junit.jupiter.api.Test;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class PasswordEncoderFactoryTests {
+
+    @Test
+    void testFactoryCreatesEncoders() {
+        PasswordEncoder bcrypt = PasswordEncoderFactory.create(HashingAlgorithm.BCRYPT);
+        assertNotNull(bcrypt);
+
+        PasswordEncoder scrypt = PasswordEncoderFactory.create(HashingAlgorithm.SCRYPT);
+        assertNotNull(scrypt);
+
+        PasswordEncoder pbkdf2 = PasswordEncoderFactory.create(HashingAlgorithm.PBKDF2);
+        assertNotNull(pbkdf2);
+
+        PasswordEncoder argon2 = PasswordEncoderFactory.create(HashingAlgorithm.ARGON2);
+        assertNotNull(argon2);
+
+        PasswordEncoder noop = PasswordEncoderFactory.create(HashingAlgorithm.NOOP);
+        assertNotNull(noop);
+    }
+}


### PR DESCRIPTION
## Summary
- implement `HashingAlgorithm` enum
- create `PasswordEncoderFactory` to build encoders
- configure encoder selection via `BCryptGeneratorAppConfig`
- expose `hashing.algorithm` property
- add unit tests for factory

## Testing
- `mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68414959c3f48330a90de439e16a004b